### PR TITLE
[TASK] Ensure PHP8.2 compatibillity for 2.13.x with proper test coverage

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -40,6 +40,7 @@ jobs:
           - "7.4"
           - "8.0"
           - "8.1"
+          - "8.2"
         dependencies:
           - "highest"
         include:
@@ -111,6 +112,7 @@ jobs:
         php-version:
           - "7.4"
           - "8.1"
+          - "8.2"
         oracle-version:
           - "21"
         include:
@@ -166,6 +168,7 @@ jobs:
         php-version:
           - "7.4"
           - "8.1"
+          - "8.2"
         oracle-version:
           - "21"
         include:
@@ -227,6 +230,8 @@ jobs:
           - "14"
         include:
           - php-version: "8.1"
+            postgres-version: "14"
+          - php-version: "8.2"
             postgres-version: "14"
 
     services:
@@ -294,6 +299,18 @@ jobs:
             mariadb-version: "10.7"
             extension: "mysqli"
           - php-version: "8.1"
+            mariadb-version: "10.7"
+            extension: "pdo_mysql"
+          - php-version: "8.2"
+            mariadb-version: "10.5"
+            extension: "mysqli"
+          - php-version: "8.2"
+            mariadb-version: "10.5"
+            extension: "pdo_mysql"
+          - php-version: "8.2"
+            mariadb-version: "10.7"
+            extension: "mysqli"
+          - php-version: "8.2"
             mariadb-version: "10.7"
             extension: "pdo_mysql"
 
@@ -438,6 +455,7 @@ jobs:
           - "7.3"
           - "7.4"
           - "8.1"
+          - "8.2"
         extension:
           - "sqlsrv"
           - "pdo_sqlsrv"

--- a/.github/workflows/static-analysis.yml
+++ b/.github/workflows/static-analysis.yml
@@ -35,6 +35,7 @@ jobs:
       matrix:
         php-version:
           - "8.1"
+          - "8.2"
 
     steps:
       - name: "Checkout code"
@@ -61,6 +62,7 @@ jobs:
       matrix:
         php-version:
           - "8.1"
+          - "8.2"
 
     steps:
       - name: Checkout code

--- a/composer.json
+++ b/composer.json
@@ -42,7 +42,7 @@
         "doctrine/coding-standard": "9.0.0",
         "jetbrains/phpstorm-stubs": "2021.1",
         "phpstan/phpstan": "1.4.6",
-        "phpunit/phpunit": "^7.5.20|^8.5|9.5.16",
+        "phpunit/phpunit": "^7.5.20 || ^8.5.30 || 9.5.25",
         "psalm/plugin-phpunit": "0.16.1",
         "squizlabs/php_codesniffer": "3.6.2",
         "symfony/cache": "^4.4",

--- a/lib/Doctrine/DBAL/Platforms/PostgreSqlPlatform.php
+++ b/lib/Doctrine/DBAL/Platforms/PostgreSqlPlatform.php
@@ -871,7 +871,7 @@ SQL
             return $callback(true);
         }
 
-        throw new UnexpectedValueException("Unrecognized boolean literal '${value}'");
+        throw new UnexpectedValueException(sprintf("Unrecognized boolean literal '%s'", $value));
     }
 
     /**


### PR DESCRIPTION
### Summary

This pull-request contains multiple commits which targets to get
proper PHP8.2 testing running and fixing detected issues. As the
`2.13.x` branch is not public active anymore this is done in a
collective way instead of single `issue`<->`pull-request` chains.

Containing commits has been created to ensure a working build-up
order. Each commit is listed here in the PR with the commit message,
from top to down.

Generally doctrine/dbal 2.13.x worked pretty good with PHP8.2,
except one issue has been detected with PostgresSQL troughh our
CI tests with PHP8.2 for TYPO3 v11. As we invested some work to
ensure that the TYPO3 code base and used 3rd party packages are
compatible an running with PHP8.2, doctrine/dbal is the last one
to give our 11LTS the new PHP8.2 version as supported version.
Thus we need to fix that, and hopefully getting a new patchlevel
release (2.13.10?) to make the TYPO3 community and agencies happy.

:information_source: Feel free to simply cherry pick and change the single commits,
commit messages and order. Do not stick to have some author kept,
if we have a merge and a release afterwards.

#### [[TASK] Update phpunit to versions without prophecy requirement](https://github.com/derrabus/dbal/commit/bfeebc18f80d81d86d61f600aaa2c3a6a3d1665f)

phpspec/prophecy was a hard dependency for phpunit, which has
changed in the latest versions of 8.5 and 9.5. phpspec/prophecy
needs to ignore php for platform requirement checks with PHP8.2

This change updates the dev dependency for phpunit to the latest
versions which do not include the hard requirement anymore. This
allows installation of phpunit with PHP8.2.

Used command(s):

```shell
composer require --dev --no-update \
  "phpunit/phpunit":"^7.5.20 || ^8.5.30 || 9.5.25"
```

#### [[TASK] Execute static code analysis with PHP8.2 in GitHub actions](https://github.com/derrabus/dbal/commit/04cb0c32f00fc794554dd8feb43ccd60926537a8)

This change adjusts the static analysis GitHub actions workflow to additionally
execute static code analisis with PHP8.2.

#### [[TASK] Enable continuous integration tests with PHP8.2](https://github.com/derrabus/dbal/commit/6e7555691d6cbc0572f1dfcaf0eabf64e9a2fca5)

This change adds PHP8.2 to the testing matrix. The additional
PHP version testing is aligned to PHP8.1 testing.

#### [[BUGFIX] Avoid deprecated variable interpolation with PHP8.2](https://github.com/derrabus/dbal/commit/712ead556238a54a25ce03bf6b409e749929a554)

This change replaces the depcrecated variable interpolation syntax
with sprintf to avoid native PHP8.2 deprecation notice while keep
compatibillity with prior PHP versions.

Sadly the platform class is loaded before PHPUnit can register it's
deprecation to exception functionality and thus only displaying the
message instead of failing the test. This would need a larger rework
to get this right, which is out of scope of this change.

The deprecation and the fix can still be verified manually with manual
steps:

* Comment the creation of the platform in the abstract testcase setup
  out (in `Doctrine\Tests\DBAL\Platforms\AbstractPlatformTestCase::setUp`):

```php
  protected function setUp(): void
  {
      //$this->platform = $this->createPlatform();
  }
```

* Execute the specific test with PHP8.2 binary

```shell
php8.2 vendor/bin/phpunit -c ci/github/phpunit/sqlite.xml \
 --filter="testThrowsExceptionWithInvalidBooleanLiteral"
```
